### PR TITLE
Add integration with production database

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-MONGO_URI=mongodb+srv://Paul:Looking1@cluster0.5nmsv.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+MONGO_URI=mongodb+srv://jbalcombe:80ie3zeQHTY7D52n@quant-db-3011.ejicw.mongodb.net/?retryWrites=true&w=majority&appName=Quant-DB-3011

--- a/app.py
+++ b/app.py
@@ -12,8 +12,8 @@ app = Flask(__name__)
 
 # Connect to MongoDB
 client = MongoClient(mongo_uri)
-db = client["qubit_database"]  # Database name
-collection = db["stocks"]  # Collection name
+db = client["quant_data"]
+collection = db["news_articles"]
 
 # GET news for a specific stock (e.g., AAPL)
 @app.route("/stocks/<symbol>", methods=["GET"])

--- a/insert_data.py
+++ b/insert_data.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 from pymongo import MongoClient
 from dotenv import load_dotenv
 
@@ -9,8 +10,8 @@ mongo_uri = os.getenv("MONGO_URI")  # Ensure this is correct
 
 try:
     client = MongoClient(mongo_uri)  # 5 sec timeout
-    db = client["qubit_database"]  # Replace with your actual DB name
-    collection = db["stocks"]
+    db = client["quant_data"]
+    collection = db["news_articles"]
 
     # Check connection
     print(client.server_info())  # Should print server details
@@ -57,6 +58,18 @@ sample_data = [
     }
 ]
 
+# Need to run the following datetime command in order for publishedAt to actually
+# be inserted in datetime format instead of just a string
+sample_data_2 = [
+    {
+        "tickers": "AAPL",
+        "title": "Apple Stock Surges After Strong Earnings Report",
+        "content": "Apple reported better-than-expected quarterly earnings, driven by strong iPhone sales and growth in its services segment.",
+        "publishedAt": datetime.datetime.fromisoformat("2025-03-10T14:30:00Z"),
+        "source": "Bloomberg"
+    }
+]
+
 # Insert data into MongoDB
-insert_result = collection.insert_many(sample_data)
+insert_result = collection.insert_many(sample_data_2)
 print(f"Inserted {len(insert_result.inserted_ids)} documents.")


### PR DESCRIPTION
This pull request adds the URI for the production database to the Data Retrieval repository, and modifies values in various fields so that data is sent to the right collection.

There are also a few other changes, including adding an example of how sample data can be inserted into the database with the date strings converted to the `date` format, using the `datetime` format (I don't think filtering by date will work if the dates are in string format, or if it is it will be harder).

(See also: [this pull request](https://github.com/pokemon47/Qubit_data_collection/pull/1) on the data collection repo)

If you still want to use your sample database for testing, you can re-add it as a separate URI
