### PR TITLE
Add functions to retrieve information from the database

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,9 +109,21 @@ def formattingADAGE(data, time_now, source_name):
         # Assumes the data variable is a list, and in the correct format for
         # ADAGE 3.0's events[] list
         adage_data["events"] = data
+    else:
+        # May have different behaviour for other news sources, but for now we
+        # assume it should do the same thing
+
+        adage_data["data_source"] = source_name
+        adage_data["dataset_type"] = "News data"
+        adage_data["dataset_id"] = "1"
+        adage_data["time_object"]["timestamp"] = time_now
+
+        # Assumes the data variable is a list, and in the correct format for
+        # ADAGE 3.0's events[] list
+        adage_data["events"] = data
     return adage_data
 
-# Function that finds the newest and oldest article in the database
+# Function that finds the date of the newest and oldest articles in the database
 # (overall, or for a particular company)
 def newest_oldest_article(source_name, company):
     if (source_name == "news_api_org"):
@@ -137,10 +149,10 @@ def newest_oldest_article(source_name, company):
 
     query.append({"$group": find_newest_oldest})
 
-    query_result = dict(collection.aggregate(find_newest_oldest))
+    query_result = list(collection.aggregate(query))
 
-    newest = query_result["newest"]
-    oldest = query_result["oldest"]
+    newest = query_result[0]["newest"]
+    oldest = query_result[0]["oldest"]
 
     return newest, oldest
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def get_stock_news(symbol):
 
 # GET news articles for a specific company
 @app.route("/articles/<source_name>/<company>", methods=["GET"])
-def get_stock_news(source_name, company):
+def get_company_news(source_name, company):
     limit = request.args.get("limit", default=10, type=int)
     start_date = request.args.get("start_date")
     end_date = request.args.get("end_date")

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request
 from pymongo import MongoClient
 from dotenv import load_dotenv
+from datetime import datetime
 import os
 
 # Load environment variables
@@ -13,11 +14,11 @@ app = Flask(__name__)
 # Connect to MongoDB
 client = MongoClient(mongo_uri)
 db = client["quant_data"]
-collection = db["news_articles"]
 
 # GET news for a specific stock (e.g., AAPL)
 @app.route("/stocks/<symbol>", methods=["GET"])
 def get_stock_news(symbol):
+    collection = db["news_articles"]
     query = {"symbol": symbol.upper()}  # Case-insensitive symbol search
     limit = request.args.get("limit", default=10, type=int)
     date = request.args.get("date")  # Optional filter by date
@@ -30,6 +31,85 @@ def get_stock_news(symbol):
         return jsonify({"message": f"No news found for {symbol}"}), 404
     
     return jsonify(stocks), 200
+
+# GET news articles for a specific company
+@app.route("/articles/<source_name>/<company>", methods=["GET"])
+def get_stock_news(source_name, company):
+    limit = request.args.get("limit", default=10, type=int)
+    start_date = request.args.get("start_date")
+    end_date = request.args.get("end_date")
+    publisher = request.args.get("publisher")
+    author = request.args.get("author")
+    exclude_publisher = request.args.get("exclude_publisher")
+    exclude_author = request.args.get("exclude_author")
+
+    # There is a separate collection for each source, since we must reconstruct
+    # the ADAGE (including the data_source field) when retreiving data
+    if (source_name == "news_api_org"):
+        collection = db["news_api"]
+    else:
+        # news_articles is the default collection to retrieve data from
+        collection = db["news_articles"]
+
+    # Use a regex to search for the company name in article titles and descriptions
+    query = {"$or": []}
+    query["$or"].append({"attribute.title": {"$regex": company, "$options": "i"}})
+    query["$or"].append({"attribute.description": {"$regex": company, "$options": "i"}})
+
+    if start_date:
+        # Only return articles written AFTER a certain date
+        query["time_object.timestamp"] = {"$gte": datetime.fromisoformat(start_date)}
+
+    if end_date:
+        # Only return articles written BEFORE a certain date
+        query["time_object.timestamp"] = {"$lte": datetime.fromisoformat(end_date)}
+
+    if publisher:
+        if exclude_publisher:
+            # Exclude articles published by a particular site
+            query["attribute.publisher"] = {"$ne": {"$regex": publisher, "$options": "i"}}
+        else:
+            # Only return articles published by a particular site
+            query["attribute.publisher"] = {"$regex": publisher, "$options": "i"}
+    
+    if author:
+        if exclude_author:
+            # Exclude articles published by a particular author
+            query["attribute.author"] = {"$ne": {"$regex": author, "$options": "i"}}
+        else:
+            # Only return articles published by a particular author
+            query["attribute.author"] = {"$regex": author, "$options": "i"}
+
+    articles = list(collection.find(query, {"_id": 0}).limit(limit))
+    if not articles:
+        return jsonify({"message": f"No news found for {company}"}), 404
+    
+    adage_data = formattingADAGE(articles, datetime.now(), source_name)
+    
+    return jsonify(adage_data), 200
+
+# Function which reconstructs retreived data in ADAGE 3.0 format    
+def formattingADAGE(data, time_now, source_name):
+    adage_data = {
+        "data_source": str,
+        "dataset_type": str,
+        "dataset_id": str,
+        "time_object": {
+            "timestamp": datetime,
+            "timezone": "UTC",
+        },
+        "events": []
+    }
+    if (source_name == "news_api_org"):
+        adage_data["data_source"] = source_name
+        adage_data["dataset_type"] = "News data"
+        adage_data["dataset_id"] = "1"
+        adage_data["time_object"]["timestamp"] = time_now
+
+        # Assumes the data variable is a list, and in the correct format for
+        # ADAGE 3.0's events[] list
+        adage_data["events"] = data
+    return adage_data
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/insert_data.py
+++ b/insert_data.py
@@ -4,9 +4,9 @@ from pymongo import MongoClient
 from dotenv import load_dotenv
 
 # Load MongoDB connection URI
-
-load_dotenv()  # Load .env variables
-mongo_uri = os.getenv("MONGO_URI")  # Ensure this is correct
+# Load .env variables
+load_dotenv()
+mongo_uri = os.getenv("MONGO_URI")
 
 try:
     client = MongoClient(mongo_uri)  # 5 sec timeout
@@ -22,54 +22,92 @@ except Exception as e:
 # Sample data
 sample_data = [
     {
-        "tickers": "AAPL",
-        "title": "Apple Stock Surges After Strong Earnings Report",
-        "content": "Apple reported better-than-expected quarterly earnings, driven by strong iPhone sales and growth in its services segment.",
-        "publishedAt": "2025-03-10T14:30:00Z",
-        "source": "Bloomberg"
+        "time_object": {
+            "timestamp": datetime.datetime.fromisoformat("2025-03-10T14:30:00Z"),
+            "duration": None,
+            "duration_unit": None,
+            "timezone": "UTC"
+        },
+        "event_type": "News article",
+        "attribute": {
+            "publisher": "Bloomberg",
+            "title": "Apple Stock Surges After Strong Earnings Report",
+            "tickers": "AAPL",
+            "author": "John Doe",
+            "description": "Apple reported better-than-expected quarterly earnings, driven by strong iPhone sales and growth in its services segment.",
+            "url": "https://doesnotexist.com"
+        }
     },
     {
-        "tickers": "AAPL",
-        "title": "Apple Faces Regulatory Scrutiny Over App Store Policies",
-        "content": "Regulators in the EU and US are investigating Apple's App Store policies for potential anti-competitive practices.",
-        "publishedAt": "2025-03-09T12:00:00Z",
-        "source": "CNBC"
+        "time_object": {
+            "timestamp": datetime.datetime.fromisoformat("2025-03-09T12:00:00Z"),
+            "duration": None,
+            "duration_unit": None,
+            "timezone": "UTC"
+        },
+        "event_type": "News article",
+        "attribute": {
+            "publisher": "CNBC",
+            "title": "Apple Faces Regulatory Scrutiny Over App Store Policies",
+            "tickers": "AAPL",
+            "author": "Jane Doe",
+            "description": "Regulators in the EU and US are investigating Apple's App Store policies for potential anti-competitive practices.",
+            "url": "https://doesnotexist.com"
+        }
     },
     {
-        "tickers": "AAPL",
-        "title": "Apple Announces New AI Features for iPhones and MacBooks",
-        "content": "Apple has unveiled a suite of AI-powered features, including enhanced Siri capabilities and real-time language translation.",
-        "publishedAt": "2025-03-08T08:45:00Z",
-        "source": "TechCrunch"
+        "time_object": {
+            "timestamp": datetime.datetime.fromisoformat("2025-03-08T08:45:00Z"),
+            "duration": None,
+            "duration_unit": None,
+            "timezone": "UTC"
+        },
+        "event_type": "News article",
+        "attribute": {
+            "publisher": "TechCrunch",
+            "title": "Apple Announces New AI Features for iPhones and MacBooks",
+            "tickers": "AAPL",
+            "author": "John Doe",
+            "description": "Apple has unveiled a suite of AI-powered features, including enhanced Siri capabilities and real-time language translation.",
+            "url": "https://doesnotexist.com"
+        }
     },
     {
-        "tickers": "AAPL",
-        "title": "Apple Stock Declines Amid Supply Chain Concerns",
-        "content": "Apple's stock dipped as investors reacted to reports of supply chain disruptions affecting iPhone production in China.",
-        "publishedAt": "2025-03-07T15:20:00Z",
-        "source": "Reuters"
+        "time_object": {
+            "timestamp": datetime.datetime.fromisoformat("2025-03-07T15:20:00Z"),
+            "duration": None,
+            "duration_unit": None,
+            "timezone": "UTC"
+        },
+        "event_type": "News article",
+        "attribute": {
+            "publisher": "Reuters",
+            "title": "Apple Stock Declines Amid Supply Chain Concerns",
+            "tickers": "AAPL",
+            "author": "Jane Doe",
+            "description": "Apple's stock dipped as investors reacted to reports of supply chain disruptions affecting iPhone production in China.",
+            "url": "https://doesnotexist.com"
+        }
     },
     {
-        "tickers": "AAPL",
-        "title": "Warren Buffett Increases Stake in Apple",
-        "content": "Berkshire Hathaway has significantly increased its investment in Apple, reinforcing its confidence in the company's future.",
-        "publishedAt": "2025-03-06T10:15:00Z",
-        "source": "Yahoo Finance"
-    }
-]
-
-# Need to run the following datetime command in order for publishedAt to actually
-# be inserted in datetime format instead of just a string
-sample_data_2 = [
-    {
-        "tickers": "AAPL",
-        "title": "Apple Stock Surges After Strong Earnings Report",
-        "content": "Apple reported better-than-expected quarterly earnings, driven by strong iPhone sales and growth in its services segment.",
-        "publishedAt": datetime.datetime.fromisoformat("2025-03-10T14:30:00Z"),
-        "source": "Bloomberg"
-    }
+        "time_object": {
+            "timestamp": datetime.datetime.fromisoformat("2025-03-06T10:15:00Z"),
+            "duration": None,
+            "duration_unit": None,
+            "timezone": "UTC"
+        },
+        "event_type": "News article",
+        "attribute": {
+            "publisher": "Yahoo Financeg",
+            "title": "Warren Buffett Increases Stake in Apple",
+            "tickers": "AAPL",
+            "author": "James Doe",
+            "description": "Berkshire Hathaway has significantly increased its investment in Apple, reinforcing its confidence in the company's future.",
+            "url": "https://doesnotexist.com"
+        }
+    },
 ]
 
 # Insert data into MongoDB
-insert_result = collection.insert_many(sample_data_2)
+insert_result = collection.insert_many(sample_data)
 print(f"Inserted {len(insert_result.inserted_ids)} documents.")


### PR DESCRIPTION
This pull request adds three functions to Data Retrieval:

- `get_company_news()`: A function which retrieves news articles from the database if their title or description contain a provided company name (case insensitive). Optionally, you can filter articles by publishing date, publisher, and author. The results are returned in ADAGE 3.0 format.
- `formattingADAGE()`: A helper function for `get_company_news()` which reconstructs the ADAGE 3.0 format from data retrieved from the database. It is similar to the function of the same name in Data Collection.
- `newest_oldest_article()`: A function that returns the `datetime` values of the newest and oldest articles in the database, either overall or for a particular company.

The `get_company_news()` function is part of a new API route, but `newest_oldest_article()` is currently unused.

I have tested all three functions individually and they seem to work on the sample data.

Additionally, the sample data has been updated to match the new DB data format that we agreed on, to assist with testing.

Limitations: `get_company_news()` only retrieves articles from the database, and can't request new data to be collected from Data Collection (yet!)